### PR TITLE
Update RxSwift dependency to "4.0"

### DIFF
--- a/RxDisplayLink.podspec
+++ b/RxDisplayLink.podspec
@@ -11,5 +11,5 @@ Pod::Spec.new do |s|
   s.source_files = "RxDisplayLink/**/*.{h,swift}"
   s.requires_arc = true
   s.frameworks   = "Foundation"
-  s.dependency "RxSwift", "~> 4.0.0"
+  s.dependency "RxSwift", "~> 4.0"
 end


### PR DESCRIPTION
Should the dependency be 4.0 to allow consuming projects to have later versions of RxSwift (than 4.0.0)?
My understanding is that "~ 4.0.0" requires that specific version which is rather restrictive.